### PR TITLE
default to host 'range' in current search domain (match er behavior)

### DIFF
--- a/erg.go
+++ b/erg.go
@@ -22,7 +22,7 @@ type Erg struct {
 
 // New(address string) returns a new erg
 // takes two arguments
-// host - hostname default - localhost
+// host - hostname default - 'range'
 // port - port default - 8080
 // ssl - use https or not default - false
 func New(host string, port int) *Erg {

--- a/main/erg.go
+++ b/main/erg.go
@@ -9,7 +9,7 @@ import (
 )
 
 var port = goopt.Int([]string{"-p", "--port"}, 8080, "Port to connect to. Can also be set with RANGE_PORT environment variable.")
-var host = goopt.String([]string{"-h", "--host"}, "localhost", "Host to connect to. Can also be set with RANGE_HOST environment variable.")
+var host = goopt.String([]string{"-h", "--host"}, "range", "Host to connect to. Can also be set with RANGE_HOST environment variable.")
 var ssl = goopt.Flag([]string{"-s", "--ssl"}, []string{"--no-ssl"},
 	"Don't use SSL", "Use SSL. Can also be set with RANGE_SSL environment variable.")
 var expand = goopt.Flag([]string{"-e", "--expand"}, []string{"--no-expand"},


### PR DESCRIPTION
This might not be desired, but it aligns with Ruby er.